### PR TITLE
Parsing Support for Sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ keywords = ["config", "configuration"]
 categories = ["config"]
 
 [dependencies]
+derive_macro = { path = "./derive_macro" }
 rust-ini = "0.21.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config-tools"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Gray Logan <literal.gray@gmail.com>"]
 description = "A simplified set of tools for working with configuration files."

--- a/derive_macro/Cargo.toml
+++ b/derive_macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "derive_macro"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1.0.87"
+quote = "1.0.37"
+syn = { version = "2.0.79", features = ["full"] }
+
+[lib]
+proc-macro = true

--- a/derive_macro/src/lib.rs
+++ b/derive_macro/src/lib.rs
@@ -1,0 +1,41 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(FromSection)]
+pub fn from_section_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let fields = match &input.data {
+        syn::Data::Struct(data_struct) => match &data_struct.fields {
+            syn::Fields::Named(fields) => &fields.named,
+            _ => panic!("Only named fields are supported"),
+        },
+        _ => panic!("Only structs are supported"),
+    };
+
+    let field_parsing = fields.iter().map(|f| {
+        let field_name = f.ident.as_ref().unwrap();
+        let field_type = &f.ty;
+
+        quote! {
+            #field_name: map.get(stringify!(#field_name))
+                .and_then(|value| value.parse::<#field_type>().ok())
+                .ok_or_else(|| config_tools::Error::ConfigParse(format!("Failed to parse field '{}'", stringify!(#field_name))))?,
+        }
+    });
+
+    let expanded = quote! {
+        use config_tools::Section;
+        impl config_tools::Section for #name {
+            fn from_section(map: &std::collections::BTreeMap<String, String>) -> Result<Self, config_tools::Error> {
+                Ok(Self {
+                    #(#field_parsing)*
+                })
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/derive_macro/src/lib.rs
+++ b/derive_macro/src/lib.rs
@@ -4,6 +4,38 @@ use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(FromSection)]
+#[doc = r#"
+    Derives the `Section` trait for a struct.
+
+    This macro generates an implementation of the `Section` trait for a struct, 
+    enabling automatic parsing of its fields from a `BTreeMap<String, String>`, 
+    which represents a section from a configuration file.
+
+    Each field in the struct must implement `FromStr`, as the macro will attempt 
+    to parse the corresponding string value for each field in the section map.
+    There is no need to import the `Section` trait, as the macro will do so
+    automatically.
+
+    # Example
+
+    ```rust
+    # use config_tools::Section;
+    #[derive(FromSection)]
+    struct ServerConfig {
+        host: String,
+        port: u16,
+    }
+
+    let config = Config::load("config.ini")?;
+    let server_section = config.section("Server").unwrap();
+    let server_config = ServerConfig::from_section(server_section)?;
+    println!("{:?}", server_config);
+    ```
+
+    In this example, the `ServerConfig` struct will automatically be populated
+    from the `[Server]` section of the `config.ini` file, with values for 
+    `host` and `port`.
+"#]
 pub fn from_section_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;

--- a/examples/get_values.rs
+++ b/examples/get_values.rs
@@ -1,5 +1,3 @@
-#![allow(unused, dead_code)]
-
 use config_tools::{sectioned_defaults, Config, FromSection};
 
 #[derive(Debug, FromSection)]
@@ -13,7 +11,7 @@ fn main() {
     let config = Config::load_or_default("get-values.ini", || sectioned_defaults! {
         {
             "console" => "true",
-            "logging" => "true",
+            "log_level" => "info",
         }
         ["Server"] {
             "address" => "127.0.0.1",
@@ -22,17 +20,15 @@ fn main() {
         }
     });
 
-    let address = config
-        .get(Some("Server"), "address")
+    let console = config
+        .get_as::<bool>(None, "console")
         .unwrap();
-
-    let port = config
-        .get_as::<u16>(Some("Server"), "port")
+    let log_level = config
+        .get(None, "log_level")
         .unwrap();
-
-    let threads: u16 = config.get_as(Some("Server"), "threads").unwrap();
 
     let server_settings = ServerSettings::from_section(&config.section("Server").unwrap()).unwrap();
 
-    println!("Server Settings: {server_settings:#?}");
+    println!("General:\n    console={:?}\n    log_level={:?}", console, log_level);
+    println!("Server:\n    address={:?}\n    port={:?}\n    threads={:?}", server_settings.address, server_settings.port, server_settings.threads);
 }

--- a/examples/get_values.rs
+++ b/examples/get_values.rs
@@ -1,4 +1,13 @@
-use config_tools::{sectioned_defaults, Config};
+#![allow(unused, dead_code)]
+
+use config_tools::{sectioned_defaults, Config, FromSection};
+
+#[derive(Debug, FromSection)]
+struct ServerSettings {
+    address: String,
+    port: u16,
+    threads: u16,
+}
 
 fn main() {
     let config = Config::load_or_default("get-values.ini", || sectioned_defaults! {
@@ -13,8 +22,6 @@ fn main() {
         }
     });
 
-    println!("{config:#?}\n---");
-
     let address = config
         .get(Some("Server"), "address")
         .unwrap();
@@ -25,9 +32,7 @@ fn main() {
 
     let threads: u16 = config.get_as(Some("Server"), "threads").unwrap();
 
-    println!("
-        Address: {address}
-        Port: {port}
-        Threads: {threads}
-    ");
+    let server_settings = ServerSettings::from_section(&config.section("Server").unwrap()).unwrap();
+
+    println!("Server Settings: {server_settings:#?}");
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,10 @@ use crate::{builder::ConfigBuilder, error::Error};
 use ini::Ini;
 use std::collections::BTreeMap;
 
+pub trait Section: Sized {
+    fn from_section(map: &BTreeMap<String, String>) -> Result<Self, Error>;
+}
+
 #[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct Config {
     pub sections: BTreeMap<String, BTreeMap<String, String>>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 #[derive(Debug)]
 pub enum Error {
     AlreadyExists,
+    ConfigParse(String),
     NotFound,
     ConfigLoad(ini::Error),
     ConfigCreation(std::io::Error),
@@ -12,6 +13,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::AlreadyExists => write!(f, "The key already exists"),
+            Error::ConfigParse(e) => write!(f, "Failed to parse config: {e}"),
             Error::NotFound => write!(f, "The key was not found"),
             Error::ConfigLoad(e) => write!(f, "Failed to load config file: {e:?}"),
             Error::ConfigCreation(e) => write!(f, "Failed to create config file: {e:?}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ mod config;
 mod error;
 mod macros;
 
-pub use config::Config;
+pub use config::{Config, Section};
 pub use error::Error;
+pub use derive_macro::FromSection;

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -49,3 +49,62 @@ fn test_config_builder_update() {
         "Host should now equal '0.0.0.0'"
     );
 }
+
+#[test]
+fn test_default_config_loading() {
+    use config_tools::sectioned_defaults;
+    let config = Config::load_or_default("nonexistent.ini", || sectioned_defaults! {
+        {
+            "console" => "true",
+            "log_level" => "info",
+        }
+        ["Server"] {
+            "address" => "127.0.0.1",
+            "port" => "8080",
+            "threads" => "4",
+        }
+    });
+
+    let console = config.get_as::<bool>(None, "console").unwrap();
+    let log_level = config.get(None, "log_level").unwrap();
+    assert_eq!(console, true);
+    assert_eq!(log_level, "info");
+
+    let address = config.get(Some("Server"), "address").unwrap();
+    let port = config.get_as::<u16>(Some("Server"), "port").unwrap();
+    let threads = config.get_as::<u16>(Some("Server"), "threads").unwrap();
+    assert_eq!(address, "127.0.0.1");
+    assert_eq!(port, 8080);
+    assert_eq!(threads, 4);
+}
+
+#[test]
+fn test_default_config_loading_with_missing_keys() {
+    use config_tools::sectioned_defaults;
+    let config = Config::load_or_default("nonexistent.ini", || sectioned_defaults! {
+        {
+            "console" => "true",
+            "log_level" => "info",
+        }
+        ["Server"] {
+            "address" => "127.0.0.1",
+            "port" => "8080",
+            "threads" => "4",
+        }
+    });
+
+    // Try to access non-existent key
+    assert!(config.get(None, "missing_key").is_none(), "Should return None for missing key");
+
+    // Try to access non-existent section
+    assert!(config.get(Some("NonExistentSection"), "any_key").is_none(), "Should return None for missing section");
+}
+
+
+#[test]
+fn test_get_as_type_mismatch() {
+    let config = Config::builder().general().set("key1", "value1").build();
+
+    let result = config.get_as::<u16>(None, "key1"); // Attempt to parse a string into u16
+    assert!(result.is_none(), "get_as should return None on type mismatch");
+}

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -1,0 +1,48 @@
+use config_tools::{sectioned_defaults, Config};
+use derive_macro::FromSection;
+
+#[derive(Debug, FromSection, PartialEq)]
+struct ServerSettings {
+    address: String,
+    port: u16,
+    threads: u16,
+}
+
+#[test]
+fn test_incomplete_section_parsing() {
+    let config = Config::load_or_default("nonexistent.ini", || sectioned_defaults! {
+        ["Server"] {
+            "address" => "192.168.1.1",  // Missing `port` and `threads`
+        }
+    });
+
+    let server_settings_result = ServerSettings::from_section(&config.section("Server").unwrap());
+    
+    assert!(
+        server_settings_result.is_err(),
+        "Parsing an incomplete section should result in an error"
+    );
+}
+
+
+#[test]
+fn test_section_parsing_into_struct() {
+    let config = Config::load_or_default("nonexistent.ini", || sectioned_defaults! {
+        ["Server"] {
+            "address" => "192.168.1.1",
+            "port" => "8000",
+            "threads" => "8",
+        }
+    });
+
+    // Parse section into a struct
+    let server_settings = ServerSettings::from_section(&config.section("Server").unwrap()).unwrap();
+
+    // Check that the values are correctly parsed into the struct
+    let expected_settings = ServerSettings {
+        address: "192.168.1.1".to_string(),
+        port: 8000,
+        threads: 8,
+    };
+    assert_eq!(server_settings, expected_settings);
+}

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -2,6 +2,37 @@
 extern crate config_tools;
 
 #[test]
+fn test_general_defaults_macro() {
+    let config = general_defaults!(
+        "key1" => "value1",
+        "key2" => "value2",
+    );
+
+    assert_eq!(config.get(None, "key1"), Some(&"value1".to_string()));
+    assert_eq!(config.get(None, "key2"), Some(&"value2".to_string()));
+    assert!(config.get(None, "key3").is_none());
+}
+
+#[test]
+fn test_mixed_defaults_macro() {
+    let config = sectioned_defaults!(
+        {
+            "general_key1" => "general_value1"
+        }
+        ["section1"] {
+            "section_key1" => "section_value1"
+        }
+    );
+
+    // General section checks
+    assert_eq!(config.get(None, "general_key1"), Some(&"general_value1".to_string()));
+
+    // Section checks
+    assert_eq!(config.get(Some("section1"), "section_key1"), Some(&"section_value1".to_string()));
+}
+
+
+#[test]
 fn test_sectioned_defaults_macro() {
     let config = sectioned_defaults!(
         ["section1"] {
@@ -20,15 +51,36 @@ fn test_sectioned_defaults_macro() {
 }
 
 #[test]
-fn test_general_defaults_macro() {
-    let config = general_defaults!(
-        "key1" => "value1",
-        "key2" => "value2",
+fn test_sectioned_defaults_macro_with_missing_section_or_key() {
+    let config = sectioned_defaults!(
+        ["section1"] {
+            "key1" => "value1",
+        }
     );
 
-    assert_eq!(config.get(None, "key1"), Some(&"value1".to_string()));
-    assert_eq!(config.get(None, "key2"), Some(&"value2".to_string()));
-    assert!(config.get(None, "key3").is_none());
+    // Missing section
+    assert!(config.get(Some("missing_section"), "key1").is_none(), "Should return None for missing section");
+
+    // Missing key in existing section
+    assert!(config.get(Some("section1"), "missing_key").is_none(), "Should return None for missing key in section");
+}
+
+
+#[test]
+fn test_sectioned_defaults_macro_with_type_parsing() {
+    let config = sectioned_defaults!(
+        ["section1"] {
+            "key1" => "100",
+            "key2" => "true",
+        }
+    );
+
+    // Type parsing with `get_as`
+    let key1: u16 = config.get_as(Some("section1"), "key1").unwrap();
+    let key2: bool = config.get_as(Some("section1"), "key2").unwrap();
+
+    assert_eq!(key1, 100);
+    assert_eq!(key2, true);
 }
 
 #[test]


### PR DESCRIPTION
# Changes in This PR
This PR introduces new features to extend functionality for parsing configuration sections into structs and improve error handling during configuration parsing. Key additions include the `FromSection` procedural macro for easier struct generation from configuration sections and a new `ConfigParse` error variant for better error reporting.

1. **Procedural Macro: `FromSection`**
   - Added the `FromSection` procedural macro to enable automatic parsing of configuration sections into user-defined structs.
   - The macro derives an implementation of the `FromSection` trait for a struct, allowing fields to be parsed directly from a `BTreeMap<String, String>`.
   - Fields must implement `FromStr` for automatic parsing from string values.

   **Example Usage:**
   ```rust
   #[derive(FromSection)]
   struct ServerConfig {
       host: String,
       port: u16,
   }

   let server_config = ServerConfig::from_section(config.section("Server").unwrap())?;
   ```

2. **New `ConfigParse` Error Variant**
   - Added a new `ConfigParse(String)` error variant to the `Error` enum, providing more specific error messages related to configuration value parsing issues.
   - This improves debugging and clarity when loading configurations and attempting to parse invalid or mismatched values.

3. **Enhanced `Config` Struct**
   - Updated the `Config` struct's `section` method to return a reference to the section’s `BTreeMap<String, String>`, allowing easier integration with the `FromSection` macro.