### PR TITLE
Remove FnOnce requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config-tools"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Gray Logan <literal.gray@gmail.com>"]
 description = "A simplified set of tools for working with configuration files."

--- a/examples/from_section.rs
+++ b/examples/from_section.rs
@@ -15,23 +15,24 @@ struct LdapSettings {
 }
 
 fn main() {
-    let config = Config::load_or_default("get-values.ini", || {
-        return sectioned_defaults! {
-            {
-                "console" => "true",
-                "log_level" => "info",
-            }
-            ["Server"] {
-                "address" => "127.0.0.1",
-                "port" => "8080",
-                "threads" => "4",
-            }
-            ["LDAP"] {
-                "host" => "ldap://localhost:389",
-                "domain" => "example.com",
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        "get-values.ini",
+        sectioned_defaults! {
+                {
+                    "console" => "true",
+                    "log_level" => "info",
+                }
+                ["Server"] {
+                    "address" => "127.0.0.1",
+                    "port" => "8080",
+                    "threads" => "4",
+                }
+                ["LDAP"] {
+                    "host" => "ldap://localhost:389",
+                    "domain" => "example.com",
+                }
+        },
+    );
 
     let ldap_settings = LdapSettings::from_section(&config.section("LDAP").unwrap()).unwrap();
     let server_settings = ServerSettings::from_section(&config.section("Server").unwrap()).unwrap();

--- a/examples/get_values.rs
+++ b/examples/get_values.rs
@@ -8,19 +8,20 @@ struct ServerSettings {
 }
 
 fn main() {
-    let config = Config::load_or_default("get-values.ini", || {
-        return sectioned_defaults! {
-            {
-                "console" => "true",
-                "log_level" => "info",
-            }
-            ["Server"] {
-                "address" => "127.0.0.1",
-                "port" => "8080",
-                "threads" => "4",
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        "get-values.ini",
+        sectioned_defaults! {
+                {
+                    "console" => "true",
+                    "log_level" => "info",
+                }
+                ["Server"] {
+                    "address" => "127.0.0.1",
+                    "port" => "8080",
+                    "threads" => "4",
+                }
+        },
+    );
 
     let console = config.get_as::<bool>(None, "console").unwrap();
     let log_level = config.get(None, "log_level").unwrap();

--- a/examples/load_file.rs
+++ b/examples/load_file.rs
@@ -8,14 +8,15 @@ fn main() {
     // let config = Config::load(filename);
 
     // Load and use defaults on failure
-    let config = Config::load_or_default(filename, || {
-        return sectioned_defaults! {
-            {
-                "host" => "127.0.0.1",
-                "port" => "8080",
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        filename,
+        sectioned_defaults! {
+                {
+                    "host" => "127.0.0.1",
+                    "port" => "8080",
+                }
+        },
+    );
 
     config.save(filename).expect("Failed to save config.");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,10 +58,10 @@ impl Config {
         })
     }
 
-    pub fn load_or_default<F: FnOnce() -> Config>(filename: &str, default: F) -> Self {
+    pub fn load_or_default(filename: &str, default: Config) -> Self {
         match Self::load(filename) {
             Ok(config) => config,
-            Err(_) => default(),
+            Err(_) => default,
         }
     }
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -53,19 +53,20 @@ fn test_config_builder_update() {
 #[test]
 fn test_default_config_loading() {
     use config_tools::sectioned_defaults;
-    let config = Config::load_or_default("nonexistent.ini", || {
-        return sectioned_defaults! {
-            {
-                "console" => "true",
-                "log_level" => "info",
-            }
-            ["Server"] {
-                "address" => "127.0.0.1",
-                "port" => "8080",
-                "threads" => "4",
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        "nonexistent.ini",
+        sectioned_defaults! {
+                {
+                    "console" => "true",
+                    "log_level" => "info",
+                }
+                ["Server"] {
+                    "address" => "127.0.0.1",
+                    "port" => "8080",
+                    "threads" => "4",
+                }
+        },
+    );
 
     let console = config.get_as::<bool>(None, "console").unwrap();
     let log_level = config.get(None, "log_level").unwrap();
@@ -83,19 +84,20 @@ fn test_default_config_loading() {
 #[test]
 fn test_default_config_loading_with_missing_keys() {
     use config_tools::sectioned_defaults;
-    let config = Config::load_or_default("nonexistent.ini", || {
-        return sectioned_defaults! {
-            {
-                "console" => "true",
-                "log_level" => "info",
-            }
-            ["Server"] {
-                "address" => "127.0.0.1",
-                "port" => "8080",
-                "threads" => "4",
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        "nonexistent.ini",
+        sectioned_defaults! {
+                {
+                    "console" => "true",
+                    "log_level" => "info",
+                }
+                ["Server"] {
+                    "address" => "127.0.0.1",
+                    "port" => "8080",
+                    "threads" => "4",
+                }
+        },
+    );
 
     // Try to access non-existent key
     assert!(

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -9,13 +9,14 @@ struct ServerSettings {
 
 #[test]
 fn test_incomplete_section_parsing() {
-    let config = Config::load_or_default("nonexistent.ini", || {
-        return sectioned_defaults! {
-            ["Server"] {
-                "address" => "192.168.1.1",  // Missing `port` and `threads`
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        "nonexistent.ini",
+        sectioned_defaults! {
+                ["Server"] {
+                    "address" => "192.168.1.1",  // Missing `port` and `threads`
+                }
+        },
+    );
 
     let server_settings_result = ServerSettings::from_section(&config.section("Server").unwrap());
 
@@ -27,15 +28,16 @@ fn test_incomplete_section_parsing() {
 
 #[test]
 fn test_section_parsing_into_struct() {
-    let config = Config::load_or_default("nonexistent.ini", || {
-        return sectioned_defaults! {
-            ["Server"] {
-                "address" => "192.168.1.1",
-                "port" => "8000",
-                "threads" => "8",
-            }
-        }
-    });
+    let config = Config::load_or_default(
+        "nonexistent.ini",
+        sectioned_defaults! {
+                ["Server"] {
+                    "address" => "192.168.1.1",
+                    "port" => "8000",
+                    "threads" => "8",
+                }
+        },
+    );
 
     // Parse section into a struct
     let server_settings = ServerSettings::from_section(&config.section("Server").unwrap()).unwrap();


### PR DESCRIPTION
# Changes in This PR
## Changes to `Config::load_or_default()`
- No longer requires a `FnOnce() -> Config` as its second argument
- Now accepts a `Config` instead, without a closure
```rust
// Before (Disliked by Clippy)
Config::load_or_default(CONFIG_INI, || {
    return sectioned_defaults! {
    // ...
    };
})
```
The issue with the original implementation was that `clippy` would recommend removing the unneeded `return` statement. Doing so, however, would lead to errors because `sectioned_defaults!` and `general_defaults!` create configurations by running `Config::builder().set("...", "...").build();` without returning anything. The only other option that wouldn't be flagged by Clippy was to format your closure this way:

```rust
// Before (Accepted by Clippy, disliked by cargo fmt)
Config::load_or_default(CONFIG_INI, || sectioned_defaults! {
    // ...
})
```
... And then running `cargo fmt` would change it to this:
```rust
// Before (Broken after cargo fmt)
Config::load_or_default(CONFIG_INI, || {
    sectioned_defaults! {
        // ...
    }
})
```
This adds curly braces around the macro and breaks the function execution immediately.

With the new implementation, you can simply do this:
```rust
// New implementation
Config::load_or_default(CONFIG_INI, sectioned_defaults! {
        // ...
})
```